### PR TITLE
perf(images): year-long image cache, correct sizes, eager LCP hero

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
   // },
   images: {
     remotePatterns: [{ hostname: "*" }],
+    // S3 objects are served without a Cache-Control header, so the image
+    // optimizer falls back to its 60s default and emits
+    // `max-age=60, must-revalidate` — which Cloudflare refuses to edge-cache.
+    // Upload keys are `randomUUID()-Date.now()-name`, so an image URL never
+    // changes content and is safe to cache for a year.
+    minimumCacheTTL: 31536000,
   },
 };
 

--- a/src/app/[locale]/contacts/page.tsx
+++ b/src/app/[locale]/contacts/page.tsx
@@ -11,6 +11,8 @@ const Contacts: React.FC = () => {
             src={"/assets/contacts-banner.png"}
             alt="Contacts Banner"
             fill
+            sizes="100vw"
+            priority
             objectFit="cover"
             objectPosition="center"
             quality={75}

--- a/src/app/[locale]/mortgage/page.tsx
+++ b/src/app/[locale]/mortgage/page.tsx
@@ -33,6 +33,7 @@ const MortgagePage: React.FC<Props> = async() => {
                 className="mt-4 rounded-lg shadow-md"
                 width={1200}
                 height={400}
+                sizes="(max-width: 1023px) 100vw, 800px"
               />
 
                 <div className="mt-6">

--- a/src/components/about-us/about-us.tsx
+++ b/src/components/about-us/about-us.tsx
@@ -20,6 +20,7 @@ export const AboutUsSection = async () => {
         width={1000}
         height={1000}
         loading="lazy"
+        sizes="45vw"
         className="hidden xl:block flex-1 object-contain shadow-lg rounded-3xl max-h-[500px]"
       />
       <Card className="p-6 sm:p-0 m-0 shadow border/75 rounded-2xl sm:border-none sm:shadow-none xl:flex-1 bg-background/[0.5%] sm:bg-transparent">

--- a/src/components/hot/offer-card.tsx
+++ b/src/components/hot/offer-card.tsx
@@ -63,6 +63,11 @@ export const OfferCard: React.FC<Props> = async ({ offert, type }) => {
           width={500}
           alt="Dialog"
           loading="lazy"
+          // Widest layout this card appears in: 1 col < 640px, 2 cols < 1024px,
+          // 3 cols above (offerts-grid). Without this, Next falls back to a
+          // 1x/2x srcset and every retina device downloads the w=1080 variant
+          // for a ~275px slot.
+          sizes="(max-width: 639px) 100vw, (max-width: 1023px) 50vw, 33vw"
           className={`h-[190px] shadow rounded-t-2xl border-b ${
             offert.media?.at(0)?.url
               ? "object-cover object-center"
@@ -74,8 +79,11 @@ export const OfferCard: React.FC<Props> = async ({ offert, type }) => {
           <Image
             src={"/assets/logo-white.png"}
             alt="logo"
-            width={1000}
-            height={1000}
+            // Intrinsic size of the asset. It was declared as 1000x1000, which
+            // made Next request a w=2048 variant for a 128px-wide overlay.
+            width={284}
+            height={100}
+            sizes="128px"
             className="w-20 lg:w-32"
           />
         </div>

--- a/src/components/landing-hero-card.tsx
+++ b/src/components/landing-hero-card.tsx
@@ -47,6 +47,10 @@ export const LandingHeroCard: React.FC<Props> = ({
           fill
           loading="lazy"
           quality={80}
+          // `fill` with no `sizes` defaults to 100vw, so each of these seven
+          // category cards was fetching a full-viewport-width variant for a
+          // slot that is at most half the viewport.
+          sizes="(max-width: 1023px) 50vw, 20vw"
         />
       </CardContent>
     </Card>

--- a/src/components/landing-hero.tsx
+++ b/src/components/landing-hero.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import { getImageProps } from "next/image";
 import React from "react";
 import { LandingHeroCard } from "./landing-hero-card";
 import { getTranslations } from "next-intl/server";
@@ -7,35 +7,57 @@ interface Props {}
 
 export const LandingHero: React.FC<Props> = async ({}) => {
   const t = await getTranslations("banner");
+
+  // This is the LCP element. It is rendered as a single <picture> rather than
+  // three breakpoint-switched <Image>s on purpose: with three of them, making
+  // the banner eager would download all three (CSS `hidden` does not stop an
+  // eager <img> from loading), while keeping them lazy delayed the LCP paint.
+  // <source media> lets the browser pick exactly one candidate and fetch it
+  // immediately at high priority.
+  const banner = (src: string, sizes: string) =>
+    getImageProps({
+      src,
+      alt: "Hero Banner Image",
+      fill: true,
+      // The banner is rendered at `brightness-50` behind headline text, so it
+      // is decorative. q65 is indistinguishable here and costs ~40% fewer
+      // bytes than q80 on the LCP element.
+      quality: 65,
+      sizes,
+    }).props;
+
+  const phone = banner("/assets/phone-hero-banner.png", "100vw");
+  const tablet = banner("/assets/tablet-hero-banner.png", "100vw");
+  // `sizes` is a CSS-pixel hint that the browser multiplies by DPR, so "100vw"
+  // made every retina desktop pick the 3840w candidate (273KB). The fixed
+  // 960px cap resolves to the 1920w candidate at DPR2 (~112KB) and trades a
+  // little sharpness on a darkened backdrop for less time-to-LCP.
+  const desktop = banner(
+    "/assets/desktop-hero-banner.png",
+    "(max-width: 1023px) 100vw, 960px",
+  );
+
   return (
     <section className="relative pt-10 sm:pt-12 h-fit w-full">
-      {/* PHONE VERSION IMAGE */}
-      <Image
-        src={"/assets/phone-hero-banner.png"}
-        alt="Hero Banner Image"
-        className="absolute brightness-50 sm:hidden"
-        fill
-        quality={80}
-        loading="lazy"
-      />
-      {/* TABLET VERSION IMAGE */}
-      <Image
-        src={"/assets/tablet-hero-banner.png"}
-        alt="Hero Banner Image"
-        className="hidden sm:block absolute brightness-50 lg:hidden"
-        fill
-        quality={80}
-        loading="lazy"
-      />
-      {/* DESTOP VERSION IMAGE */}
-      <Image
-        src={"/assets/desktop-hero-banner.png"}
-        alt="Hero Banner Image"
-        className="hidden lg:block absolute brightness-50"
-        fill
-        quality={80}
-        loading="lazy"
-      />
+      <picture>
+        <source
+          media="(max-width: 639px)"
+          srcSet={phone.srcSet}
+          sizes={phone.sizes}
+        />
+        <source
+          media="(max-width: 1023px)"
+          srcSet={tablet.srcSet}
+          sizes={tablet.sizes}
+        />
+        <img
+          {...desktop}
+          className="absolute brightness-50"
+          fetchPriority="high"
+          loading="eager"
+          decoding="async"
+        />
+      </picture>
       <div className="w-full px-6 sm:px-11 lg:px-20 flex justify-center items-center">
         <div className="relative h-full z-10 py-10 sm:py-14 flex flex-col justify-between gap-8 sm:gap-12 w-full max-w-7xl">
           <div className="flex justify-center">

--- a/src/components/mortgage/button-group.tsx
+++ b/src/components/mortgage/button-group.tsx
@@ -51,6 +51,7 @@ const PrimaCasaPrograms = () => {
                                 alt={programs[activeProgram].title}
                                 width={800}
                                 height={400}
+                                sizes="(max-width: 1023px) 100vw, 700px"
                                 className="w-full h-auto mb-4 rounded"
                             />
                             {programs[activeProgram].content?.details.map((detail, index) => (

--- a/src/components/news/news-card.tsx
+++ b/src/components/news/news-card.tsx
@@ -28,6 +28,7 @@ export const NewsCard: React.FC<Props> = async ({
         alt={content.title_ro}
         width={500}
         height={228}
+        sizes="(max-width: 639px) 100vw, (max-width: 1023px) 50vw, 33vw"
         className={`h-56 w-full shadow rounded-xl ${
           thumbnail ? "object-cover" : "p-20 object-contain"
         }`}

--- a/src/components/partners/partners.tsx
+++ b/src/components/partners/partners.tsx
@@ -27,6 +27,7 @@ export const PartnersSection: React.FC<Props> = async ({}) => {
                   alt={partner}
                   width={500}
                   height={500}
+                  sizes="(max-width: 639px) 50vw, (max-width: 1279px) 33vw, 25vw"
                   className="h-full w-full object-center object-contain p-4 sm:p-10 lg:p-16 grayscale hover:grayscale-0 transition duration-500 hover:scale-125"
                 />
               </CarouselItem>

--- a/src/components/services/service-card.tsx
+++ b/src/components/services/service-card.tsx
@@ -75,6 +75,7 @@ export const ServiceCard: React.FC<Props> = ({
           alt={img?.alt as string}
           height={500}
           width={500}
+          sizes="(max-width: 1279px) 100vw, 280px"
           className="w-full xl:max-w-[280px] h-[200px] sm:h-[230px] xl:h-[320px] object-cover rounded-xl shadow"
         />
       )}

--- a/src/components/team/member-card.tsx
+++ b/src/components/team/member-card.tsx
@@ -20,6 +20,7 @@ export const MemberCard: React.FC<Props> = async ({ member }) => {
       <Image
         src={member.thumbnail || "/assets/logo-blue.png"}
         fill
+        sizes="(max-width: 639px) 100vw, (max-width: 1023px) 50vw, (max-width: 1279px) 33vw, 25vw"
         alt=""
         className={`rounded-2xl h-full w-full ${
           member.thumbnail ? "p-0 object-cover" : "p-20 object-contain"

--- a/src/features/blogs/components/blog-article.tsx
+++ b/src/features/blogs/components/blog-article.tsx
@@ -27,6 +27,7 @@ export const BlogArticle: React.FC<Props> = ({ blog, locale }) => {
         height={500}
         quality={80}
         loading="lazy"
+        sizes="(max-width: 1023px) 100vw, 66vw"
         className={`w-full h-full max-h-[500px] object-center min-h-56 shadow-lg rounded-2xl border ${
           blog.thumbnail
             ? "object-cover"

--- a/src/features/blogs/components/blog-card.tsx
+++ b/src/features/blogs/components/blog-card.tsx
@@ -44,6 +44,7 @@ export const BlogCard: React.FC<Props> = async ({ blog, locale }) => {
             width={500}
             height={500}
             quality={80}
+            sizes="(max-width: 639px) 100vw, (max-width: 1023px) 50vw, 33vw"
             className={`w-full h-60 object-center rounded-lg shadow border/50  ${
               !blog.thumbnail ? "object-contain p-20" : "object-cover"
             }`}

--- a/src/features/offerts/components/offert-carousel.tsx
+++ b/src/features/offerts/components/offert-carousel.tsx
@@ -27,6 +27,8 @@ export default function OffertCarousel({ media }: { media: Media[] }) {
               alt={media[currentIndex].url}
               width={1000}
               height={1000}
+              priority
+              sizes="(max-width: 1279px) 95vw, 65vw"
               className="w-full lg:h-[500px] object-cover rounded-md  transition-all duration-300"
             />
 
@@ -34,8 +36,9 @@ export default function OffertCarousel({ media }: { media: Media[] }) {
               <Image
                 src={"/assets/logo-white.png"}
                 alt="logo"
-                width={1000}
-                height={1000}
+                width={284}
+                height={100}
+                sizes="160px"
                 className="w-20 lg:w-40 h-auto"
               />
             </div>
@@ -48,14 +51,16 @@ export default function OffertCarousel({ media }: { media: Media[] }) {
               alt={media[currentIndex].url}
               width={1000}
               height={1000}
+              sizes="85vw"
               className="rounded-2xl h-full w-full object-contain bg-transparent"
             />
             <div className="absolute bottom-0 left-0 w-full flex justify-center items-center pb-4 md:pb-10 lg:pb-20">
               <Image
                 src={"/assets/logo-white.png"}
                 alt="logo"
-                width={1000}
-                height={1000}
+                width={284}
+                height={100}
+                sizes="384px"
                 className="w-20 md:w-40 lg:w-60 xl:w-80 2xl:w-96 h-auto"
               />
             </div>
@@ -128,6 +133,10 @@ export default function OffertCarousel({ media }: { media: Media[] }) {
                   alt={media.url}
                   width={1000}
                   height={1000}
+                  // These render in ~148px-wide slots (basis-1/5). Declared at
+                  // 1000px with no `sizes`, every retina device was pulling the
+                  // w=2048 variant for each one.
+                  sizes="(max-width: 639px) 20vw, (max-width: 1279px) 16vw, 11vw"
                   className="w-full h-full object-cover rounded-md hover:scale-105 transition-all duration-300"
                 />
 
@@ -135,8 +144,9 @@ export default function OffertCarousel({ media }: { media: Media[] }) {
                   <Image
                     src={"/assets/logo-white.png"}
                     alt="logo"
-                    width={1000}
-                    height={1000}
+                    width={284}
+                    height={100}
+                    sizes="80px"
                     className="w-20 h-auto"
                   />
                 </div>

--- a/src/features/services/components/service-article.tsx
+++ b/src/features/services/components/service-article.tsx
@@ -27,6 +27,7 @@ export const ServiceArticle: React.FC<Props> = ({ service, locale }) => {
         height={500}
         quality={80}
         loading="lazy"
+        sizes="(max-width: 1023px) 100vw, 66vw"
         className={`w-full h-full max-h-[500px] object-center min-h-56 shadow-lg rounded-2xl border ${
           service.thumbnail
             ? "object-cover"


### PR DESCRIPTION
Three separate causes of slow image loading, in order of cost.

1. Nothing cached images. S3 objects carry no Cache-Control, so the image optimizer fell back to its 60s default and emitted `max-age=60, must-revalidate`, which Cloudflare refuses to edge-cache (cf-cache-status: DYNAMIC on every repeat request). Meanwhile /_next/static/* was cached for a year and returned HIT. Setting minimumCacheTTL fixes already-stored images too - no re-upload.

2. `sizes` was set on zero images. With an explicit width and no `sizes`, Next emits a 1x/2x srcset, so every retina device took the 2x candidate regardless of slot size. Detail-page carousel thumbnails requested w=2048 for a 148x108 slot; grid cards requested w=1080 for ~275px. Same photo through the optimizer: w=1080 59.6KB, w=640 25.6KB, w=384 11.9KB.

3. The LCP hero was lazy-loaded and served at w=3840 (273KB). It is now a single <picture>: three breakpoint-switched <Image>s could not simply be made eager, because CSS `hidden` does not stop an eager <img> from loading and all three would download. <source media> picks exactly one, fetched eagerly at high priority. Now w=1920 q65, 112KB.

Verified against a production build: Cache-Control 60s -> 31536000s, one hero request instead of three, carousel thumbs w=2048 -> w=256.